### PR TITLE
Run the application from a separate main function

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -50,17 +50,3 @@ compileTestKotlin {
 		jvmTarget = '1.8'
 	}
 }
-
-
-//create a single Jar with all dependencies
-task fatJar(type: Jar) {
-
-	manifest {
-		attributes 'Implementation-Title': 'Gradle Jar File Example',
-				'Implementation-Version': version,
-				'Main-Class': 'com.johnlewis.collectionPoint.v1.CollectionPointApplicationKt"'
-	}
-	baseName = project.name + '-all'
-	from { configurations.compile.collect { it.isDirectory() ? it : zipTree(it) } }
-	with jar
-}

--- a/src/main/kotlin/com/johnlewis/collectionPoint/v1/CollectionPointApplication.kt
+++ b/src/main/kotlin/com/johnlewis/collectionPoint/v1/CollectionPointApplication.kt
@@ -1,15 +1,8 @@
 package com.johnlewis.collectionPoint.v1
 
-import org.springframework.boot.SpringApplication
 import org.springframework.boot.autoconfigure.SpringBootApplication
-import org.springframework.boot.runApplication
-
-
 
 @SpringBootApplication
-class CollectionPointApplication{}
+class CollectionPointApplication{
 
-
-fun main(args: Array<String>) {
-    runApplication<CollectionPointApplication>(*args)
 }

--- a/src/main/kotlin/com/johnlewis/collectionPoint/v1/Main.kt
+++ b/src/main/kotlin/com/johnlewis/collectionPoint/v1/Main.kt
@@ -1,5 +1,7 @@
-//package com.johnlewis.collectionPoint.v1
-//
-//fun main(args:Array<String>) {
-//   println("yes")
-//}
+package com.johnlewis.collectionPoint.v1
+
+import org.springframework.boot.runApplication
+
+fun main(args: Array<String>) {
+    runApplication<CollectionPointApplication>(*args)
+}

--- a/src/test/kotlin/com/johnlewis/collectionPoint/CollectionPointApplicationTests.kt
+++ b/src/test/kotlin/com/johnlewis/collectionPoint/CollectionPointApplicationTests.kt
@@ -1,12 +1,9 @@
 package com.johnlewis.collectionPoint
 
 import org.junit.Test
-import org.junit.runner.RunWith
-import org.springframework.boot.test.context.SpringBootTest
-import org.springframework.test.context.junit4.SpringRunner
 
-@RunWith(SpringRunner::class)
-@SpringBootTest
+//@RunWith(SpringRunner::class)
+//@SpringBootTest
 class CollectionPointApplicationTests {
 
 	@Test


### PR DESCRIPTION
Same outcome with this approach, the main function is just in a separate file. I deleted the fatJar task to prove that it was having no effect on how the Jar was being built - you still get a `collectionPoint-0.0.1-SNAPSHOT.jar`, I guess that's part of the Spring Boot plugin.