### PR TITLE
Original code still in place

### DIFF
--- a/src/test/kotlin/com/johnlewis/collectionPoint/CollectionPointApplicationTests.kt
+++ b/src/test/kotlin/com/johnlewis/collectionPoint/CollectionPointApplicationTests.kt
@@ -1,12 +1,9 @@
 package com.johnlewis.collectionPoint
 
 import org.junit.Test
-import org.junit.runner.RunWith
-import org.springframework.boot.test.context.SpringBootTest
-import org.springframework.test.context.junit4.SpringRunner
 
-@RunWith(SpringRunner::class)
-@SpringBootTest
+//@RunWith(SpringRunner::class)
+//@SpringBootTest
 class CollectionPointApplicationTests {
 
 	@Test

--- a/src/test/kotlin/com/johnlewis/collectionPoint/CollectionPointApplicationTests.kt
+++ b/src/test/kotlin/com/johnlewis/collectionPoint/CollectionPointApplicationTests.kt
@@ -1,9 +1,15 @@
 package com.johnlewis.collectionPoint
 
+import com.johnlewis.collectionPoint.v1.CollectionPointApplication
 import org.junit.Test
+import org.junit.runner.RunWith
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.test.context.ContextConfiguration
+import org.springframework.test.context.junit4.SpringRunner
 
-//@RunWith(SpringRunner::class)
-//@SpringBootTest
+@RunWith(SpringRunner::class)
+@SpringBootTest
+@ContextConfiguration(classes = [CollectionPointApplication::class])
 class CollectionPointApplicationTests {
 
 	@Test


### PR DESCRIPTION
Demonstrates that your code was correct just that the tests needed to run before the Jar could be generated.